### PR TITLE
Resolve userspace linking, attempt QEMU fixes, ongoing boot issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ initrd: userspace_build
 
 # Cible pour exécuter l'OS dans QEMU
 run: $(OS_IMAGE) initrd
-	# Lancer QEMU avec le noyau ET l'initrd, headless, focus on guest errors
-	qemu-system-i386 -kernel $(OS_IMAGE) -initrd my_initrd.tar -nographic -serial stdio -d guest_errors -no-reboot -no-shutdown
+	# Lancer QEMU avec le noyau ET l'initrd, headless, serial multiplexé sur stdio, more verbose debug
+	qemu-system-i386 -kernel $(OS_IMAGE) -initrd my_initrd.tar -nographic -serial mon:stdio -d int,cpu_reset,guest_errors -no-reboot -no-shutdown
 
 # Cible pour nettoyer le projet
 clean:

--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ initrd: userspace_build
 
 # Cible pour exécuter l'OS dans QEMU
 run: $(OS_IMAGE) initrd
-	# Lancer QEMU avec le noyau ET l'initrd et les options de débogage, attempting to get CPU reset logs
-	qemu-system-i386 -kernel $(OS_IMAGE) -initrd my_initrd.tar -serial stdio -d int,cpu_reset,guest_errors -no-reboot -no-shutdown
+	# Lancer QEMU avec le noyau ET l'initrd, headless, focus on guest errors
+	qemu-system-i386 -kernel $(OS_IMAGE) -initrd my_initrd.tar -nographic -serial stdio -d guest_errors -no-reboot -no-shutdown
 
 # Cible pour nettoyer le projet
 clean:

--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ initrd: userspace_build
 
 # Cible pour exécuter l'OS dans QEMU
 run: $(OS_IMAGE) initrd
-	# Lancer QEMU avec le noyau ET l'initrd et les options de débogage, log vers fichier
-	qemu-system-i386 -kernel $(OS_IMAGE) -initrd my_initrd.tar -nographic -serial stdio -d int,cpu_reset,guest_errors -D qemu_log.txt -no-reboot -no-shutdown
+	# Lancer QEMU avec le noyau ET l'initrd et les options de débogage, TENTATIVE AVEC STDIO SANS NOGRAPHIC
+	qemu-system-i386 -kernel $(OS_IMAGE) -initrd my_initrd.tar -serial stdio -d int,cpu_reset,guest_errors -no-reboot -no-shutdown
 
 # Cible pour nettoyer le projet
 clean:

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ initrd: userspace_build
 
 # Cible pour exécuter l'OS dans QEMU
 run: $(OS_IMAGE) initrd
-	# Lancer QEMU avec le noyau ET l'initrd et les options de débogage, TENTATIVE AVEC STDIO SANS NOGRAPHIC
+	# Lancer QEMU avec le noyau ET l'initrd et les options de débogage, attempting to get CPU reset logs
 	qemu-system-i386 -kernel $(OS_IMAGE) -initrd my_initrd.tar -serial stdio -d int,cpu_reset,guest_errors -no-reboot -no-shutdown
 
 # Cible pour nettoyer le projet

--- a/userspace/Makefile
+++ b/userspace/Makefile
@@ -1,7 +1,9 @@
 CC = gcc
 LD = ld
 CFLAGS = -m32 -ffreestanding -nostdlib -fno-pie -I.
-LDFLAGS = -m elf_i386 -Ttext=0x40000000 --oformat binary
+# Output ELF files and specify 'main' as the entry point.
+# Using a common base address for simple user programs.
+LDFLAGS = -m elf_i386 -Ttext=0x00010000 --entry=main
 
 # Cibles par défaut
 all: shell.bin fake_ai.bin


### PR DESCRIPTION
- Corrected userspace Makefile to produce valid ELF executables with 'main' as the entry point, resolving linker warnings.
- Modified main Makefile to adjust QEMU serial and logging options in an attempt to get debug output.
- Ensured Multiboot header in boot.s is correct.
- Added early VGA debug print in _start.

Despite these changes, the OS still fails to boot in QEMU, likely due to a very early issue (before kmain is reached). Debugging has been hampered by tool timeouts and lack of QEMU log output.