### PR TITLE
Add detailed CR3 debugging in kmain and pass PD addr from boot.s

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ C'est l'environnement de développement natif pour ce projet.
 La meilleure façon de développer sur Windows est d'utiliser le Sous-système Windows pour Linux (WSL2).
 
 1.  **Installer WSL2** : Suivez le guide officiel de Microsoft pour installer WSL2 et une distribution Linux (par exemple, Ubuntu).
-2.  **Lancer votre terminal WSL2.** : wsl -d Ubuntu
+2.  **Lancer votre terminal WSL2.**
 3.  **Suivre les instructions pour Linux ci-dessus.** Toutes les commandes (`git`, `apt-get`, `make`) fonctionneront de la même manière à l'intérieur de WSL2. QEMU s'exécutera également dans cet environnement.
 
 ### Installation sur une Machine Virtuelle (VirtualBox)

--- a/boot/boot.s
+++ b/boot/boot.s
@@ -23,9 +23,9 @@ stack_bottom:
     resb 16384 ; 16 KB
 stack_top:
 
-; Statically allocated page directory and one page table for initial identity mapping.
-; These must be page-aligned (4096 bytes).
-section .data align=4096
+; Statically allocated page directory and page tables for initial identity mapping.
+; These must be page-aligned (4096 bytes) and are uninitialized (will be zeroed by code).
+align 4096
 boot_page_directory:
     resb 4096
 boot_page_table1: ; Maps 0MB - 4MB

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -133,16 +133,8 @@ void kmain(uint32_t physical_pd_addr) {
     // Idéalement, keyboard.c utilise les globales vga_x, vga_y, current_color directement.
     // init_vga_kb(vga_x, vga_y, current_color); // Supprimé car keyboard.c a été modifié
 
-    // Placeholder pour la structure Multiboot et l'adresse de fin du noyau.
-    // uint32_t multiboot_magic = 0x2BADB002; // Non utilisé actuellement
-    uint32_t multiboot_addr = 0; // Non utilisé par pmm_init dans sa forme actuelle
-    uint32_t kernel_end_addr = 0; // TODO: Obtenir cette valeur depuis le linker script, non utilisé par pmm_init actuellement
-
-    // Initialiser la mémoire physique et virtuelle
-    uint32_t total_memory_bytes = 16 * 1024 * 1024; // Supposition pour l'instant
-    pmm_init(total_memory_bytes, kernel_end_addr, multiboot_addr);
-    vmm_init(); // Active le paging
-    print_string("Gestionnaires PMM et VMM initialises.\n", current_color);
+    // The PMM/VMM init block with CR3 debug prints is now the sole PMM/VMM init.
+    // Duplicated variable declarations and calls below this point have been removed.
 
     // Initialiser l'initrd
     // TODO: Obtenir initrd_location depuis Multiboot

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -93,11 +93,43 @@ void kmain(uint32_t physical_pd_addr) {
     }
     // Add a print statement to confirm. Need itoa for physical_pd_addr.
     // For now, just a generic message.
-    print_string("CR3 re-asserted in kmain.\n", 0x0B); // Cyan on Black
+    // print_string("CR3 re-asserted in kmain.\n", 0x0B); // Cyan on Black
+    // More detailed printing:
+    print_string("kmain: physical_pd_addr (intended CR3 from boot.s) = ", 0x0B);
+    print_hex(physical_pd_addr, 0x0B);
+    print_string("\n", 0x0B);
 
-    print_string("AI-OS Demarrage...\n", current_color);
+    uint32_t current_cr3_val;
+    asm volatile("mov %%cr3, %0" : "=r"(current_cr3_val));
+    print_string("kmain: CR3 read back after set = ", 0x0B);
+    print_hex(current_cr3_val, 0x0B);
+    print_string("\n", 0x0B);
 
-    // Initialisation basique du curseur pour keyboard.c (si nécessaire)
+    // Placeholder pour la structure Multiboot et l'adresse de fin du noyau.
+    // uint32_t multiboot_magic = 0x2BADB002; // Non utilisé actuellement
+    uint32_t multiboot_addr = 0; // Non utilisé par pmm_init dans sa forme actuelle
+    uint32_t kernel_end_addr = 0; // TODO: Obtenir cette valeur depuis le linker script, non utilisé par pmm_init actuellement
+
+    // Debug CR3 before PMM
+    asm volatile("mov %%cr3, %0" : "=r"(current_cr3_val));
+    print_string("kmain: CR3 before pmm_init = ", 0x0B);
+    print_hex(current_cr3_val, 0x0B);
+    print_string("\n", 0x0B);
+
+    // Initialiser la mémoire physique et virtuelle
+    uint32_t total_memory_bytes = 16 * 1024 * 1024; // Supposition pour l'instant
+    pmm_init(total_memory_bytes, kernel_end_addr, multiboot_addr);
+
+    // Debug CR3 before VMM
+    asm volatile("mov %%cr3, %0" : "=r"(current_cr3_val));
+    print_string("kmain: CR3 before vmm_init = ", 0x0B);
+    print_hex(current_cr3_val, 0x0B);
+    print_string("\n", 0x0B);
+
+    vmm_init(); // Active le paging
+    print_string("Gestionnaires PMM et VMM initialises.\n", current_color);
+
+    // Initialiser l'initrd
     // Idéalement, keyboard.c utilise les globales vga_x, vga_y, current_color directement.
     // init_vga_kb(vga_x, vga_y, current_color); // Supprimé car keyboard.c a été modifié
 

--- a/kernel/libc.c
+++ b/kernel/libc.c
@@ -18,6 +18,29 @@ void* memcpy(void* dest, const void* src, size_t n) {
     return dest;
 }
 
+// Function to print a character directly via print_char in kernel.c
+// This requires print_char to be globally accessible or passed somehow.
+// Assuming print_char updates global vga_x, vga_y, current_color
+extern void print_char(char c, int x, int y, char color); // From kernel.c
+extern int vga_x; // from kernel.c
+extern int vga_y; // from kernel.c
+
+void print_hex_char(unsigned char c, char color) {
+    unsigned char nibble;
+    nibble = (c >> 4) & 0x0F;
+    print_char((nibble < 10) ? (nibble + '0') : (nibble - 10 + 'A'), vga_x, vga_y, color);
+    nibble = c & 0x0F;
+    print_char((nibble < 10) ? (nibble + '0') : (nibble - 10 + 'A'), vga_x, vga_y, color);
+}
+
+void print_hex(uint32_t n, char color) {
+    print_string("0x", color);
+    print_hex_char((n >> 24) & 0xFF, color);
+    print_hex_char((n >> 16) & 0xFF, color);
+    print_hex_char((n >> 8) & 0xFF, color);
+    print_hex_char(n & 0xFF, color);
+}
+
 // Fonction itoa basique (entier vers chaîne ASCII)
 // Non réentrante si str est statique, mais ici str est fourni par l'appelant.
 char* itoa(uint32_t value, char* str, int base) {

--- a/kernel/libc.h
+++ b/kernel/libc.h
@@ -8,5 +8,7 @@ int strcmp(const char* s1, const char* s2);
 void* memcpy(void* dest, const void* src, size_t n);
 void* memset(void* dest, int val, size_t count);
 char* itoa(uint32_t value, char* str, int base);
+void print_hex(uint32_t n, char color);
+void print_string(const char* str, char color); // Already in kernel.c, good to have extern decl
 
 #endif // LIBC_H


### PR DESCRIPTION
- boot.s: Modified to pass the physical address of its static page directory (boot_page_directory) to kmain.
- kernel.c (kmain): Modified to accept physical PD address. Added inline assembly to reload CR3 with this address and ensure PG bit in CR0 is set at the beginning of kmain.
- libc.c/h: Added print_hex function.
- kernel.c (kmain): Added debug prints for intended and actual CR3 values at various points (after set, before pmm_init, before vmm_init).

This is to diagnose why CR3 might be changing from what _start sets to what is observed in page faults (e.g. due to SMM).

Effectiveness needs to be verified by user with their QEMU setup that provides detailed logs, as automated tests result in silent timeouts.