### PR TITLE
Feat(run): Enable graphical output for QEMU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ initrd: userspace_build
 
 # Cible pour exécuter l'OS dans QEMU
 run: $(OS_IMAGE) initrd
-	# Lancer QEMU avec le noyau ET l'initrd, headless, serial multiplexé, verbose debug, no network
-	qemu-system-i386 -kernel $(OS_IMAGE) -initrd my_initrd.tar -nographic -serial mon:stdio -d int,cpu_reset,guest_errors -no-reboot -no-shutdown -net none
+	# Lancer QEMU avec le noyau ET l'initrd, avec affichage graphique, serial multiplexé, verbose debug, no network
+	qemu-system-i386 -kernel $(OS_IMAGE) -initrd my_initrd.tar -serial mon:stdio -d int,cpu_reset,guest_errors -no-reboot -no-shutdown -net none
 
 # Cible pour nettoyer le projet
 clean:


### PR DESCRIPTION
Removed the -nographic option from the QEMU command in the Makefile's 'run' target. This allows QEMU to open a graphical window to display the operating system's VGA output, facilitating visual debugging and interaction.