### PR TITLE
Fix: Correct user mode transition and context switch

### DIFF
--- a/boot/context_switch.s
+++ b/boot/context_switch.s
@@ -6,43 +6,54 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 section .text                 ; All code and data from here should be in .text
     global context_switch
 
-    %define OFF_EAX    0
-    %define OFF_EBX    4
-    %define OFF_ECX    8
-    %define OFF_EDX    12
-    %define OFF_ESI    16
-    %define OFF_EDI    20
-    %define OFF_EBP    24
-    %define OFF_EIP    28
-    %define OFF_ESP    32
-    %define OFF_EFLAGS 36
+    ; Offsets dans cpu_state_t (doivent correspondre à task.h)
+    ; Ces offsets sont relatifs au début de la structure cpu_state_t
+    ; %define OFF_EAX    0  ; Non utilisé directement par ce switch, PUSHAD/POPAD gère
+    ; %define OFF_EBX    4
+    ; %define OFF_ECX    8
+    ; %define OFF_EDX    12
+    ; %define OFF_ESI    16
+    ; %define OFF_EDI    20
+    ; %define OFF_EBP    24
+    %define OFF_ESP    28  ; Pointeur vers la pile noyau où l'état (registres, EFLAGS, trame iret) est sauvegardé
+    ; %define OFF_EIP    32  ; Non utilisé, EIP est sur la pile pour IRET
+    ; %define OFF_EFLAGS 36  ; Non utilisé, EFLAGS est sur la pile pour IRET/POPFD
 
 context_switch:
-    push esi
-    push edi
+    ; Arguments sur la pile du scheduler (appelant C):
+    ; [esp+0] = Adresse de retour vers le scheduler (après l'appel à context_switch)
+    ; [esp+4] = old_state_ptr (pointeur vers la TCB de l'ancienne tâche)
+    ; [esp+8] = new_state_ptr (pointeur vers la TCB de la nouvelle tâche)
 
-    mov esi, [esp + 12]  ; esi = old_state_ptr
-    mov edi, [esp + 16]  ; edi = new_state_ptr
+    ; --- Sauvegarder l'état de l'ancienne tâche ---
+    mov esi, [esp + 4]      ; esi = old_state_ptr
 
-    mov eax, [esp + 8]
-    mov [esi + OFF_EIP], eax
+    ; Sauvegarder les registres sur la pile actuelle (celle du noyau de l'ancienne tâche)
+    pushfd                  ; Pousse EFLAGS de l'ancienne tâche
+    pushad                  ; Pousse EAX, ECX, EDX, EBX, ESP_original, EBP, ESI, EDI de l'ancienne tâche
+                            ; ESP_original est l'ESP *avant* PUSHAD.
 
-    lea eax, [esp + 12]
-    mov [esi + OFF_ESP], eax
+    ; Sauvegarder le pointeur de pile actuel (qui pointe maintenant vers EDI sauvegardé par PUSHAD)
+    ; dans la TCB de l'ancienne tâche. C'est l'ESP du noyau de l'ancienne tâche.
+    mov [esi + OFF_ESP], esp
 
-    mov [esi + OFF_EBP], ebp
-    pushfd
-    pop dword [esi + OFF_EFLAGS]
+    ; --- Restaurer l'état de la nouvelle tâche ---
+    mov edi, [esp + 8]      ; edi = new_state_ptr (TCB de la nouvelle tâche)
+                            ; esp n'a pas changé depuis le début de cette fonction pour l'accès aux args.
 
+    ; Charger l'ESP du noyau de la nouvelle tâche.
+    ; Cet ESP (stocké dans new_state_ptr->cpu_state.esp) doit pointer vers :
+    ;   - La trame PUSHAD (EDI au sommet), puis EFLAGS.
+    ;   - Pour une nouvelle tâche utilisateur, au-dessus de cela, la trame IRET (EIP, CS, EFLAGS, ESP_user, SS_user).
     mov esp, [edi + OFF_ESP]
-    mov ebp, [edi + OFF_EBP]
 
-    push dword [edi + OFF_EFLAGS]
-    popfd
+    ; Restaurer les registres généraux et EFLAGS depuis la pile noyau de la nouvelle tâche
+    popad                   ; Restaure EDI, ESI, EBP, ESP_dummy, EBX, EDX, ECX, EAX
+                            ; ESP_dummy est ignoré, l'ESP est restauré à sa valeur avant pushad.
+    popfd                   ; Restaure EFLAGS
 
-    push dword [edi + OFF_EIP]
-
-    pop edi
-    pop esi
-
-    ret
+    iret                    ; Saute vers EIP_new, CS_new avec EFLAGS_new (déjà restauré par popfd),
+                            ; et charge ESP_new, SS_new si changement de privilège.
+                            ; Si pas de changement de privilège (noyau -> noyau), seuls EIP, CS, EFLAGS
+                            ; sont effectivement chargés depuis la pile (SS:ESP ne sont pas touchés si CPL identique).
+                            ; Pour une transition vers le mode utilisateur, les 5 valeurs sont dépilées.


### PR DESCRIPTION
- Modified `create_user_process` in `kernel/task/task.c` to:
  - Allocate a dedicated kernel stack for user tasks.
  - Prepare this kernel stack with the necessary iret frame (EIP_user, CS_user, EFLAGS_user, ESP_user, SS_user) and a PUSHAD frame (general registers initialized to 0) for the first launch.
  - Set the new task's kernel ESP to point to this prepared stack.

- Modified `boot/context_switch.s` to:
  - Correctly save all general-purpose registers and EFLAGS of the old task onto its kernel stack using PUSHFD/PUSHAD.
  - Store the resulting kernel stack pointer in the old task's TCB.
  - Load the new task's kernel stack pointer.
  - Restore all general-purpose registers and EFLAGS from the new task's kernel stack using POPAD/POPFD.
  - Use `iret` to perform the context switch, enabling proper CPL changes and segment loading for user mode tasks.

These changes address a critical bug preventing tasks from being launched correctly in user mode.