### PR TITLE
Fix: Use objcopy-generated symbols for binary size

### DIFF
--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -114,14 +114,12 @@ int create_user_process(const char* path_in_initrd, char* const argv_from_caller
     // DEBUG: Utiliser une couleur distinctive pour les messages de create_user_process
     char debug_color = 0x0E; // Jaune sur noir pour le débogage
 
-    // Déclarations pour les symboles du linker pour les binaires embarqués
-    extern uint8_t _shell_bin_start[];
-    extern uint8_t _shell_bin_end[]; // Nouveau
-    // extern uint32_t _shell_bin_size; // Supprimé
+    // Déclarations pour les symboles du linker pour les binaires embarqués (générés par objcopy)
+    extern uint8_t _binary_shell_bin_start[];
+    extern uint8_t _binary_shell_bin_end[];
 
-    extern uint8_t _fake_ai_bin_start[];
-    extern uint8_t _fake_ai_bin_end[]; // Nouveau
-    // extern uint32_t _fake_ai_bin_size; // Supprimé
+    extern uint8_t _binary_fake_ai_bin_start[];
+    extern uint8_t _binary_fake_ai_bin_end[];
 
     print_string("DEBUG_CUP: Entered create_user_process for: ", debug_color); print_string(path_in_initrd, debug_color); print_string("\n", debug_color);
 
@@ -132,13 +130,13 @@ int create_user_process(const char* path_in_initrd, char* const argv_from_caller
 
     // Comparer path_in_initrd pour déterminer quel binaire charger
     if (strcmp(path_in_initrd, "shell.bin") == 0) {
-        elf_data = _shell_bin_start;
-        elf_file_size = (uint32_t)(_shell_bin_end - _shell_bin_start);
-        print_string("DEBUG_CUP: Loading embedded shell.bin. Addr: ", debug_color); print_hex((uint32_t)elf_data, debug_color); print_string(", Size (calc): ", debug_color); print_hex(elf_file_size, debug_color); print_string("\n", debug_color);
+        elf_data = _binary_shell_bin_start;
+        elf_file_size = (uint32_t)(_binary_shell_bin_end - _binary_shell_bin_start);
+        print_string("DEBUG_CUP: Loading embedded shell.bin. Addr: ", debug_color); print_hex((uint32_t)elf_data, debug_color); print_string(", Size (objcopy): ", debug_color); print_hex(elf_file_size, debug_color); print_string("\n", debug_color);
     } else if (strcmp(path_in_initrd, "fake_ai.bin") == 0) {
-        elf_data = _fake_ai_bin_start;
-        elf_file_size = (uint32_t)(_fake_ai_bin_end - _fake_ai_bin_start);
-        print_string("DEBUG_CUP: Loading embedded fake_ai.bin. Addr: ", debug_color); print_hex((uint32_t)elf_data, debug_color); print_string(", Size (calc): ", debug_color); print_hex(elf_file_size, debug_color); print_string("\n", debug_color);
+        elf_data = _binary_fake_ai_bin_start;
+        elf_file_size = (uint32_t)(_binary_fake_ai_bin_end - _binary_fake_ai_bin_start);
+        print_string("DEBUG_CUP: Loading embedded fake_ai.bin. Addr: ", debug_color); print_hex((uint32_t)elf_data, debug_color); print_string(", Size (objcopy): ", debug_color); print_hex(elf_file_size, debug_color); print_string("\n", debug_color);
     } else {
         print_string("DEBUG_CUP: Unknown application requested: ", 0x0C); print_string(path_in_initrd, 0x0C); print_string("\n", 0x0C);
         asm volatile("sti");

--- a/linker.ld
+++ b/linker.ld
@@ -47,14 +47,10 @@ SECTIONS
     /* Section pour les applications utilisateur embarquées */
     .user_apps : ALIGN(4K)
     {
-        _shell_bin_start = .;
+        /* Les symboles _binary_shell_bin_start, _binary_shell_bin_end,
+           _binary_fake_ai_bin_start, _binary_fake_ai_bin_end
+           sont fournis par les fichiers .o créés par objcopy. */
         *(.data.shell_bin) /* Section de userspace/shell_bin.o */
-        _shell_bin_end = .;
-        PROVIDE(_shell_bin_size = _shell_bin_end - _shell_bin_start);
-
-        _fake_ai_bin_start = .;
         *(.data.fake_ai_bin) /* Section de userspace/fake_ai_bin.o */
-        _fake_ai_bin_end = .;
-        PROVIDE(_fake_ai_bin_size = _fake_ai_bin_end - _fake_ai_bin_start);
     } :data /* Placer cette section dans le segment 'data' (RW) */
 }

--- a/userspace/Makefile
+++ b/userspace/Makefile
@@ -14,6 +14,8 @@ shell.o: shell.c
 
 shell.bin: shell.o
 	$(LD) $(LDFLAGS) -o $@ $<
+	@echo "Taille de shell.bin :"
+	@ls -l $@
 
 shell_bin.o: shell.bin
 	objcopy -I binary -O elf32-i386 -B i386 --rename-section .data=.data.shell_bin shell.bin shell_bin.o
@@ -24,6 +26,8 @@ fake_ai.o: fake_ai.c
 
 fake_ai.bin: fake_ai.o
 	$(LD) $(LDFLAGS) -o $@ $<
+	@echo "Taille de fake_ai.bin :"
+	@ls -l $@
 
 fake_ai_bin.o: fake_ai.bin
 	objcopy -I binary -O elf32-i386 -B i386 --rename-section .data=.data.fake_ai_bin fake_ai.bin fake_ai_bin.o


### PR DESCRIPTION
- Modified kernel/task/task.c to use _binary_shell_bin_start and _binary_shell_bin_end (and equivalents for fake_ai.bin) symbols, which are generated by objcopy, to determine the start address and calculate the size of embedded user-space applications.
- Removed manually defined _shell_bin_start, _shell_bin_end, and size symbols from the linker script (linker.ld) for the .user_apps section.

This change relies on the standard symbols provided by objcopy when embedding raw binary files, aiming for a more robust way to determine the binary sizes and resolve previous issues where the size was incorrectly calculated as zero or a very large erroneous value.