### PR TITLE
Debug: Add VGA color change for early init function tracing

### DIFF
--- a/kernel/idt.c
+++ b/kernel/idt.c
@@ -19,6 +19,9 @@ void idt_set_gate(uint8_t num, uint32_t base, uint16_t sel, uint8_t flags) {
 
 // Initialise l'IDT entière
 void idt_init() {
+    volatile unsigned short* video_debug_idt = (unsigned short*)0xB8000;
+    video_debug_idt[0] = (video_debug_idt[0] & 0x00FF) | (0xCF00); // Fond RougeVif au début de idt_init
+
     extern void print_string(const char* str, char color); // Pour le débogage
     extern void print_hex(uint32_t n, char color); // Pour le débogage
 

--- a/kernel/syscall/syscall.c
+++ b/kernel/syscall/syscall.c
@@ -148,6 +148,9 @@ void syscall_handler(void* stack_ptr_raw) { // Le type cpu_state_t* est trompeur
 }
 
 void syscall_init() {
+    volatile unsigned short* video_debug_syscall = (unsigned short*)0xB8000;
+    video_debug_syscall[1] = (video_debug_syscall[1] & 0x00FF) | (0xAF00); // Fond BleuCiel pour 2ème char au début de syscall_init
+
     // Déclarations externes pour print_string/print_hex si elles ne sont pas déjà visibles globalement
     // extern void print_string(const char* str, char color); // Normalement visible via syscall.h -> task.h -> ... -> libc.h
     // extern void print_hex(uint32_t n, char color);       // Idem


### PR DESCRIPTION
This commit introduces direct VGA memory manipulation at the beginning of `idt_init()` and `syscall_init()` to visually confirm their execution, independently of the `print_string` function's state at that early stage.

Changes:
- In `kernel/idt.c` (`idt_init`): The background color of the first character cell (0,0) on the screen is changed to bright red.
- In `kernel/syscall/syscall.c` (`syscall_init`): The background color of the second character cell (0,1) on the screen is changed to light blue.

This will help determine if these critical initialization functions are being called, even if standard print debugging is not yet reliable.