### PR TITLE
Debug: Test IDT loading and basic exception handling with int $3

### DIFF
--- a/kernel/interrupts.c
+++ b/kernel/interrupts.c
@@ -136,7 +136,19 @@ void fault_handler(void* esp_at_call) {
     // Commented out clear screen to ensure our VGA debug markers are not erased if fault occurs very early.
     // vga_x = 0; vga_y = 0; // Reset internal cursor for print_char if it were used
 
-    if (int_num == 13) { // General Protection Fault
+    if (int_num == 3) { // Breakpoint Exception
+        id_char = 'B'; // For Breakpoint
+        vga[4] = (unsigned short)'B' | (0xE000); // 5th char, 'B' Jaune sur Fond Noir (E=Jaune, 0=Noir)
+                                                 // On écrase le caractère et la couleur.
+        // On pourrait aussi juste changer le fond: vga[4] = (vga[4] & 0x00FF) | (0xE000);
+        // Pas besoin d'afficher "BPF" etc. pour ce test, le changement de couleur suffit.
+        // On va quand même afficher quelque chose pour être sûr.
+        vga[0] = (unsigned short)id_char | (0x0E << 8); // Jaune sur Noir
+        vga[1] = (unsigned short)'P' | (0x0E << 8);
+        vga[2] = (unsigned short)' ' | (0x0E << 8);
+
+
+    } else if (int_num == 13) { // General Protection Fault
         id_char = 'G'; // For GPF
         vga[3] = (vga[3] & 0x00FF) | (0x5F00); // 4th char, Fond Magenta, Texte BlancBrillant 'G'
         vga[0] = (unsigned short)id_char | (0x0C << 8);

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -137,8 +137,20 @@ void kmain(uint32_t physical_pd_addr) {
     // Initialiser les interruptions et les appels système
     idt_init();
     interrupts_init();  // Configure le PIC, active les IRQ de base
+
+    // Test de l'IDT avec int $3 (Breakpoint)
+    // Ce message ne s'affichera que si print_string fonctionne déjà ici.
+    // Le vrai test est le changement de couleur VGA dans fault_handler pour int 3.
+    print_string("KMAIN: Declenchement de int $3 pour tester l'IDT...\n", 0x0B); // Cyan
+    asm volatile("int $3");
+    // Si le handler pour int $3 fonctionne et fait hlt, on ne devrait pas voir le message suivant.
+    // S'il fait juste un changement de couleur et iret, on le verra.
+    // Notre fault_handler actuel fait hlt.
+    print_string("KMAIN: Retour de int $3 (si iret a ete utilise et non hlt).\n", 0x0B);
+
+
     syscall_init();     // Enregistre le handler pour int 0x80
-    print_string("IDT, PIC et Syscalls initialises.\n", current_color);
+    print_string("IDT, PIC et Syscalls initialises.\n", current_color); // Ce message pourrait ne pas être atteint si int $3 fait hlt
 
     // Initialiser le multitâche
     tasking_init(); // Crée la tâche noyau initiale (idle task)


### PR DESCRIPTION
This commit introduces a test to verify the functionality of IDT loading and basic CPU exception handling.

Changes:
- In `kernel/interrupts.c` (`fault_handler`):
    - Added specific VGA output for Breakpoint Exception (int #3). It changes the 5th character cell on screen to a yellow 'B' on a black background and prints "BP " at the top-left. The handler then halts the system.
- In `kernel/kernel.c` (`kmain`):
    - An `asm volatile("int $3");` instruction is inserted immediately after `idt_init()` and `interrupts_init()`.
    - Debug print messages are added before and after the `int $3` call.

Expected behavior:
If the IDT is loaded correctly and basic exceptions are handled, the screen's 5th character should change as described, "BP " should be printed, and the system should halt before proceeding further with kernel initialization (like syscall_init or multitasking).

If the VGA change for int #3 is not observed and the system continues booting, it points to a fundamental issue with IDT loading or the CPU's ability to vector to the basic exception handlers.