### PR TITLE
Debug: Verify IDTR contents using SIDT after LIDT

### DIFF
--- a/kernel/idt.c
+++ b/kernel/idt.c
@@ -43,4 +43,17 @@ void idt_init() {
     print_string("DEBUG_IDT_INIT: Calling idt_load(&idtp).\n", 0x0D);
     idt_load(&idtp); // Pass the address of idtp
     print_string("DEBUG_IDT_INIT: Returned from idt_load(). IDT should be active.\n", 0x0D);
+
+    // Vérifier la valeur de IDTR avec SIDT
+    struct idt_ptr current_idtr;
+    asm volatile ("sidt %0" : "=m"(current_idtr));
+    print_string("DEBUG_IDT_INIT: SIDT check: current_idtr.limit=", 0x0D); print_hex(current_idtr.limit, 0x0D);
+    print_string(", current_idtr.base=", 0x0D); print_hex(current_idtr.base, 0x0D); print_string("\n", 0x0D);
+
+    if (current_idtr.limit == idtp.limit && current_idtr.base == idtp.base) {
+        print_string("DEBUG_IDT_INIT: SIDT matches idtp. LIDT successful.\n", 0x0A); // Vert
+    } else {
+        print_string("DEBUG_IDT_INIT: SIDT MISMATCH! LIDT may have failed or IDTR changed.\n", 0x0C); // Rouge
+        print_string("  Expected limit: ", 0x0C); print_hex(idtp.limit, 0x0C); print_string(", base: ", 0x0C); print_hex(idtp.base, 0x0C); print_string("\n", 0x0C);
+    }
 }


### PR DESCRIPTION
This commit adds a check in `kernel/idt.c` at the end of the `idt_init()` function to verify the contents of the CPU's Interrupt Descriptor Table Register (IDTR) immediately after `lidt` is called.

Changes:
- In `kernel/idt.c` (`idt_init`):
    - An `asm volatile("sidt ...")` instruction is used to read the current IDTR (base and limit) into a local `struct idt_ptr`.
    - The read values are printed to the debug output.
    - These values are compared against the `idtp` structure that was intended to be loaded. A success or mismatch message is printed accordingly.

This test aims to confirm whether the `lidt` instruction successfully updates the CPU's IDTR. If `sidt` shows matching values, `lidt` worked. If not, `lidt` failed or the IDTR was altered, which would explain why interrupts (like the `int $3` test or `int $0x80`) are not being correctly vectored.