### PR TITLE
Debug: ISR3 entry test with VGA modification and halt

### DIFF
--- a/boot/isr_stubs.s
+++ b/boot/isr_stubs.s
@@ -4,6 +4,16 @@ bits 32
 global isr%1
 isr%1:
     cli                ; Disable interrupts
+
+    %if %1 == 3        ; Specific test for ISR3 (Breakpoint)
+        ; VGA direct modification for ISR3 entry test
+        mov edi, 0xB8000
+        mov word [edi + 6*2], 0x1F42 ; 7th char: 'B' (0x42) White on Blue (0x1F)
+    isr3_loop:
+        hlt            ; Halt or loop to prevent further execution for this test
+        jmp isr3_loop
+    %endif
+
     push byte 0        ; Push a dummy error code
     push byte %1       ; Push the interrupt number
     jmp isr_common_stub


### PR DESCRIPTION
This commit modifies the ISR stub generation in `boot/isr_stubs.s` for `isr3` (Breakpoint exception) to perform a direct VGA modification and then halt.

Changes:
- In `boot/isr_stubs.s`, the `ISR_NOERRCODE` macro now has a conditional block for interrupt #3:
    - If the interrupt is #3, after `cli`, it immediately changes the 7th character cell on the VGA screen to a white 'B' on a blue background.
    - It then enters an infinite loop (`hlt; jmp loop`) to prevent further execution and clearly indicate if this code path is reached.
    - The usual `push` instructions and `jmp isr_common_stub` are bypassed for `isr3` in this test configuration.

This test is designed to definitively determine if the CPU vectors to the registered `isr3` handler code. If the VGA modification is observed, it confirms the IDT and gate descriptor for #3 are correct and the CPU is jumping to the handler's address. The problem would then lie in the subsequent original stub code or common C handler path. If the VGA change is not seen, it points to a failure in the CPU's ability to use the IDT to reach the handler code, despite `lidt` appearing successful.