### PR TITLE
Debug: Partially restore isr_common_stub for further testing

### DIFF
--- a/boot/isr_stubs.s
+++ b/boot/isr_stubs.s
@@ -30,34 +30,57 @@ irq%1:
 
 ; Common stub for ISRs (CPU exceptions)
 isr_common_stub:
-    ; Test VGA direct pour vérifier l'entrée dans isr_common_stub
-    mov edi, 0xB8000
-    mov word [edi + 7*2], 0x2F43 ; 8th char: 'C' (0x43) White on Green (0x2F)
+    ; Test VGA direct pour vérifier l'entrée dans isr_common_stub (peut être commenté plus tard)
+    ; mov edi, 0xB8000
+    ; mov word [edi + 7*2], 0x2F43 ; 8th char: 'C' (0x43) White on Green (0x2F)
 
-stub_loop:
-    hlt
-    jmp stub_loop
+    pusha              ; Pushes edi,esi,ebp,esp,ebx,edx,ecx,eax
 
-    ; Code original commenté pour ce test:
-    ; pusha              ; Pushes edi,esi,ebp,esp,ebx,edx,ecx,eax
-    ; mov ax, ds         ; Lower 16-bits of eax = ds.
-    ; push eax           ; save the data segment descriptor
-    ; mov ax, 0x10       ; load the kernel data segment descriptor
+    ; Les changements de segment sont commentés pour l'instant
+    ; mov ax, ds
+    ; push eax
+    ; mov ax, 0x10
     ; mov ds, ax
     ; mov es, ax
     ; mov fs, ax
     ; mov gs, ax
-    ;
-    ; call fault_handler ; Call C handler
-    ;
-    ; pop ebx            ; reload the original data segment descriptor
+
+    ; L'argument pour fault_handler est implicitement ESP après pusha
+    ; (ou après push eax si les segments étaient actifs).
+    ; fault_handler s'attend à ce que les registres soient sur la pile.
+    ; ESP après pusha pointe vers EDI. fault_handler s'attend à ce que
+    ; int_num et err_code soient plus haut sur la pile (poussés par ISR_NOERRCODE/ERRCODE).
+    ; Le `esp_at_call` dans fault_handler(void* esp_at_call) doit être interprété
+    ; comme le ESP *avant* le `call fault_handler`.
+    ; La fonction C fault_handler accède aux éléments via ce pointeur.
+    ; Pour l'instant, nous passons ESP tel quel.
+    ; Le `esp_at_call` sera ESP après `pusha`.
+    ; Le `fault_handler` C devra être conscient de cela s'il accède aux registres.
+    ; Rappel: fault_handler C utilise: ((uint32_t*)esp_at_call)[10] pour int_num.
+    ; Si esp_at_call = ESP après pusha:
+    ; [esp_at_call+0] = EDI
+    ; ...
+    ; [esp_at_call+28] = EAX
+    ; [esp_at_call+32] = int_num (poussé par la macro ISR_NOERRCODE/ERRCODE avant jmp isr_common_stub)
+    ; [esp_at_call+36] = err_code (poussé par CPU ou macro avant jmp isr_common_stub)
+    ; Donc, pour int_num, l'index serait 8 (32/4). Pour err_code, index 9 (36/4).
+    ; L'ancien code [10] était basé sur une autre convention de passage de pile.
+    ; Nous devons corriger cela dans fault_handler C si ce stub fonctionne.
+    ; Pour ce test, fault_handler ne devrait pas essayer de lire int_num trop agressivement.
+    ; Il affiche 'B' 'P' pour int 3, ce qui est un test suffisant pour l'instant.
+
+    call fault_handler ; Call C handler
+
+    ; Les restaurations de segment sont commentées
+    ; pop ebx
     ; mov ds, bx
     ; mov es, bx
     ; mov fs, bx
     ; mov gs, bx
-    ; popa               ; Pops edi,esi,ebp...
-    ; add esp, 8         ; Cleans up the pushed error code and pushed ISR number
-    ; iret               ; pops 5 things at once: CS, EIP, EFLAGS, SS, ESP
+
+    popa               ; Pops edi,esi,ebp...
+    add esp, 8         ; Cleans up the pushed error code and pushed ISR number
+    iret               ; pops 5 things at once: CS, EIP, EFLAGS, SS, ESP
 
 ; Common stub for IRQs (Hardware interrupts)
 irq_common_stub:


### PR DESCRIPTION
This commit modifies `boot/isr_stubs.s` to test the core components of `isr_common_stub`.

Changes:
- In `isr_common_stub`:
    - `pusha` is now active.
    - Instructions for changing data segments (writing to ds, es, fs, gs and saving/restoring the original ds) remain **commented out**.
    - `call fault_handler` is now active.
    - `popa`, `add esp, 8`, and `iret` are now active.
- The direct VGA modification and halt loop previously in `isr_common_stub` for testing its entry have been removed.
- Comments have been added regarding potential adjustments needed for accessing stack elements (like int_num) in the C `fault_handler` due to the current stack layout.

This test aims to determine if `pusha`, `call fault_handler` (with the C handler performing its VGA modifications for int #3 and then halting), `popa`, and `iret` function correctly without the data segment manipulations.

If the system correctly displays the VGA markers for `int $3` from the C `fault_handler` and halts, it implies these stack and call/return operations are working. The issue would then likely be with the data segment switching logic. If it still fails before the C handler's VGA output, the problem could be `pusha` (if ESP is invalid) or the way `fault_handler` is called/entered, or how it accesses stack arguments.