### PR TITLE
Fix: Correct initial EFLAGS for idle task in tasking_init

### DIFF
--- a/kernel/task/task.c
+++ b/kernel/task/task.c
@@ -42,8 +42,9 @@ void tasking_init() {
     current_task->cpu_state.eip = 0;
     current_task->cpu_state.esp = 0;
     current_task->cpu_state.ebp = 0;
-    // eflags pour la tâche initiale du noyau (idle task). IF = 0 pour l'instant.
-    current_task->cpu_state.eflags = 0x00000002; // Bit 1 est toujours 1.
+    // eflags pour la tâche initiale du noyau (idle task).
+    // Mettre IF=1 (0x200) + bit 1 (0x2) = 0x202
+    current_task->cpu_state.eflags = 0x00000202;
     current_task->next = (struct task*)current_task;
     current_task->parent = NULL;
     current_task->child_pid_waiting_on = 0;


### PR DESCRIPTION
This commit corrects the initialization of `current_task->cpu_state.eflags` within the `tasking_init` function in `kernel/task/task.c`.

The EFLAGS for the initial idle task (kmain) was previously set to `0x00000002`, which does not include the Interrupt Enable Flag (IF, bit 9). This meant that if the scheduler switched to the idle task after an interrupt, and the idle task's EFLAGS (with IF=0) were restored, subsequent hardware interrupts (like keyboard or timer) would be ignored by the CPU.

The fix changes the initialization to `0x00000202`, which includes:
- Bit 1 (Reserved, always 1) = 0x002
- Bit 9 (IF - Interrupt Enable) = 0x200

This ensures that the idle task, when running, allows hardware interrupts to be processed, which is crucial for keyboard input and timer-based scheduling to continue functioning correctly.